### PR TITLE
prioritized max-age over expires (RFC6265, 5.3.2)

### DIFF
--- a/cookies.py
+++ b/cookies.py
@@ -649,6 +649,12 @@ def parse_one_response(line, ignore_bad_cookies=False,
         elif 'year2' in captured:
             for key in timekeys:
                 del captured[key + "2"]
+        # prioritize max-age over expires, see RFC6265, section 5.3.2
+        max_age = captured.get('max_age')
+        if max_age:
+            expires_derived_from_max_age = datetime.datetime.utcnow() + \
+                datetime.timedelta(seconds=long(max_age))
+            captured['expires'] = render_date(expires_derived_from_max_age)
         cookie_dict.update(captured)
     return cookie_dict
 

--- a/test_cookies.py
+++ b/test_cookies.py
@@ -1456,6 +1456,31 @@ class TestCookies(object):
         assert Cookie.from_dict(response_dict) == \
                 Cookie('a', 'b', expires=parse_date(asctime))
 
+    def test_max_age_gets_prioritized(self):
+        """
+        Due to RFC6265 Section 5.3.3, the Max-Age attribute has to be
+        prioritized over the Expires attribute:
+
+        If the cookie-attribute-list contains an attribute with an
+        attribute-name of "Max-Age":
+
+           Set the cookie's persistent-flag to true.
+
+           Set the cookie's expiry-time to attribute-value of the last
+           attribute in the cookie-attribute-list with an attribute-name
+           of "Max-Age".
+        """
+        expires_rendered = 'Tue, 01 Jan 2013 00:00:00 GMT'
+        max_age = 3600
+        line = 'a=b; Expires=%s; Max-Age=%d' % (expires_rendered, max_age)
+        response_dict = parse_one_response(line)
+
+        assert response_dict.get('expires') != expires_rendered
+
+        now_ut = long(datetime.utcnow().strftime('%s'))
+        expires_ut = long(parse_date(response_dict['expires']).strftime('%s'))
+        assert (expires_ut - now_ut) in [max_age, max_age-1]  # might take a s
+
     def test_get_all(self):
         cookies = Cookies.from_request('a=b; a=c; b=x')
         assert cookies['a'].value == 'b'


### PR DESCRIPTION
When there is both a Max-Age and an Expires attribute, the Max-Age must be prioritized to define the expiration of the cookie (RFC6265, section 5.3.2). I fixed that and wrote a regression test. Best, Fabian
