### PR TITLE
Invalid UTF-8 value raises UnicodeDecodeError

### DIFF
--- a/cookies.py
+++ b/cookies.py
@@ -353,7 +353,7 @@ def parse_string(data, unquote=default_unquote):
     # which will therefore not normalize as unicode and not compare to
     # the original.
     if isinstance(unquoted, bytes):
-        unquoted = unquoted.decode('utf-8')
+        unquoted = unquoted.decode('utf-8', 'replace')
     return unquoted
 
 

--- a/test_cookies.py
+++ b/test_cookies.py
@@ -2081,6 +2081,7 @@ test_parse_string = _simple_test(parse_string, {
     None: None,
     '': '',
     b'': '',
+    b'%80': '\ufffd',
     })
 
 test_parse_domain = _simple_test(parse_domain, {


### PR DESCRIPTION
Using quoting, a cookie value can have any byte sequence. When the sequence is invalid UTF-8, Cookie raises an UnicodeDecodeError.

This is an example of a bad cookie:

```
$ curl -b C=%80 http://webappusingcookie:8000
```

Depending of the web application implementation, that request can give a 500 error or raise a UnicodeDecodeError.

I suggest to use `.decode('utf-8-, 'replace')` in `parse_string` method. I also have added a test case.
