### PR TITLE
Allow changing the Cookie class

### DIFF
--- a/cookies.py
+++ b/cookies.py
@@ -869,8 +869,8 @@ class Cookie(object):
             value = renderer(value)
         return '; '.join(
             ['{0}={1}'.format(name, value)] +
-            [key if isinstance(value, bool) else '='.join((key, value))
-             for key, value in self.attributes().items()]
+            [key if isinstance(val, bool) else '='.join((key, val))
+             for key, val in self.attributes().items()]
         )
 
     def __eq__(self, other):

--- a/cookies.py
+++ b/cookies.py
@@ -968,6 +968,9 @@ class Cookies(dict):
     stored in the dict, and render the set in formats suitable for HTTP request
     or response headers.
     """
+
+    COOKIE_CLASS = Cookie
+
     def __init__(self, *args, **kwargs):
         dict.__init__(self)
         self.all_cookies = []
@@ -990,7 +993,7 @@ class Cookies(dict):
                 continue
             self[cookie.name] = cookie
         for key, value in kwargs.items():
-            cookie = Cookie(key, value)
+            cookie = self.COOKIE_CLASS(key, value)
             self.all_cookies.append(cookie)
             if key in self:
                 continue


### PR DESCRIPTION
Allow changing the Cookie class used by Cookies; otherwise, you cannot configure the parsers and validators to use in Cookies.

In the past I used to monkey-patch the Cookie class, which is less than ideal.
