### PR TITLE
stop parse_domain from stripping initial dot?

### DIFF
--- a/cookies.py
+++ b/cookies.py
@@ -163,9 +163,9 @@ class Definitions(object):
     # Domain attribute; a label is one part of the domain
     LABEL = '{let_dig}(?:(?:{let_dig_hyp}+)?{let_dig})?'.format(
             let_dig="[A-Za-z0-9]", let_dig_hyp="[0-9A-Za-z\-]")
-    DOMAIN = "(?:{label}\.)*(?:{label})".format(label=LABEL)
+    DOMAIN = "\.?(?:{label}\.)*(?:{label})".format(label=LABEL)
     # Parse initial period though it's wrong, as RFC 6265 4.1.2.3
-    DOMAIN_AV = "Domain=(?P<domain>\.?{domain})".format(domain=DOMAIN)
+    DOMAIN_AV = "Domain=(?P<domain>{domain})".format(domain=DOMAIN)
 
     # Path attribute. We don't take special care with quotes because
     # they are hardly used, they don't allow invalid characters per RFC 6265,
@@ -403,9 +403,6 @@ def parse_domain(value):
     """Parse and validate an incoming Domain attribute value.
     """
     value = strip_spaces_and_quotes(value)
-    # Strip/ignore invalid leading period as in RFC 5.2.3
-    if value and value[0] == '.':
-        value = value[1:]
     if value:
         assert valid_domain(value)
     return value
@@ -495,8 +492,6 @@ def valid_domain(domain):
     # Using encoding on domain would confuse browsers into not sending cookies.
     # Generate UnicodeDecodeError up front if it can't store as ASCII.
     domain.encode('ascii')
-    if domain and domain[0] in '."':
-        return False
     # Domains starting with periods are not RFC-valid, but this is very common
     # in existing cookies, so they should still parse with DOMAIN_AV.
     if Definitions.DOMAIN_RE.match(domain):

--- a/test_cookies.py
+++ b/test_cookies.py
@@ -863,8 +863,6 @@ class TestCookie(object):
             # invalid domain
             (("w", "m"), {'domain': ''}, InvalidCookieAttributeError),
             (("w", "m"), {'domain': '@'}, InvalidCookieAttributeError),
-            (("w", "m"), {'domain': '.foo.net'},
-                InvalidCookieAttributeError),
             # control: valid domain
             (("w", "m"),
                 {'domain': 'foo.net'},
@@ -1867,20 +1865,20 @@ HEADER_CASES = [
             InvalidCookieError,
             Cookies(Cookie('lu', "Qg3OHJZLehYLjVgAqiZbZbzo",
                 expires=parse_date('Tue, 15 Jan 2013 21:47:38 GMT'),
-                path='/', domain='foo.com', httponly=True,
+                path='/', domain='.foo.com', httponly=True,
                 ))),
         ('ZQID=AYBEVnDKrdst; Domain=.nauk.com; Path=/; '
          'Expires=Wed, 13-Jan-2021 22:23:01 GMT; HttpOnly', {},
             InvalidCookieError,
             Cookies(Cookie('ZQID', "AYBEVnDKrdst",
-                httponly=True, domain='nauk.com', path='/',
+                httponly=True, domain='.nauk.com', path='/',
                 expires=parse_date('Wed, 13 Jan 2021 22:23:01 GMT'),
                 ))),
         ("OMID=Ap4PQQEq; Domain=.nauk.com; Path=/; "
             'Expires=Wed, 13-Jan-2021 22:23:01 GMT; Secure; HttpOnly', {},
             InvalidCookieError,
             Cookies(Cookie('OMID', "Ap4PQQEq",
-                path='/', domain='nauk.com', secure=True, httponly=True,
+                path='/', domain='.nauk.com', secure=True, httponly=True,
                 expires=parse_date('Wed, 13 Jan 2021 22:23:01 GMT')
                 ))),
         # question mark in value
@@ -2135,7 +2133,6 @@ test_parse_domain = _simple_test(parse_domain, {
     '  foo   ': 'foo',
     '"foo"': 'foo',
     '  "foo"  ': 'foo',
-    '.foo': 'foo',
     })
 
 test_parse_path = _simple_test(parse_path, {
@@ -2341,7 +2338,6 @@ test_valid_domain = _simple_test(valid_domain,
         ' ': False,
         '.': False,
         '..': False,
-        '.foo': False,
         '"foo"': False,
         'foo': True,
     })


### PR DESCRIPTION
Hmm. What do others think about this? 

parse liberally, render conservatively - of course I'm keeping that. But as currently written, there are strings which are neither 'reject this cookie/attribute' nor 'pass it on downstream' - like the initial dot on domain attributes found in set-response strings, which I am silently allowing but stripping _during parse_.

Is it the parser's responsibility to preserve original information where there's a strong case that it's useful? But if so, doesn't that make it the caller's responsibility to strip that information to ensure sanity/compliance? And if that would have to be done routinely as part of basic good practice, is it really "friendly" for cookies to pass the buck to every single user there (e.g. to write some awful wrapper, like sane_cookies)?

---

Unlike spaces and quotes, this initial dot character could carry information
that might be of interest to the caller who is parsing a Set-Response line.

Arguably it should be up to the user-agent itself, not the parsing library
called by the user-agent, to ignore the initial dot.

After all, I went far enough to leave the initial dot in DOMAIN_AV regexp specifically to
let this initial period through... and also wrote in a comment:

```
# Domains starting with periods are not RFC-valid, but this is very common
# in existing cookies, so they should still parse with DOMAIN_AV.
```

Then I wrote DOMAIN_AV so that the attribute would parse without vomiting.

Perhaps, as a separate change, generated renders should strip the dot.
At least via the default renderer. 
