### PR TITLE
MAX_AGE_AV regexp: account for Max-Age=0

### DIFF
--- a/cookies.py
+++ b/cookies.py
@@ -158,7 +158,7 @@ class Definitions(object):
 
     # Max-Age attribute. These are digits, they are expressed this way
     # because that is how they are expressed in the RFC.
-    MAX_AGE_AV = "Max-Age=(?P<max_age>[\x31-\x39][\x30-\x39]*)"
+    MAX_AGE_AV = "Max-Age=(?P<max_age>[\x30-\x39]+)"
 
     # Domain attribute; a label is one part of the domain
     LABEL = '{let_dig}(?:(?:{let_dig_hyp}+)?{let_dig})?'.format(


### PR DESCRIPTION
Some of the web frameworks (e.g. Plone) use the following trick to clear cookies after logout:
Set-Cookie: auth=deleted; Max-Age=0 
cookies.py currently chokes in those cases because the RFC forbids that (the leading digit must be non-zero).
...
I think the "liberal parsing" principle should be applied here to make this library more useful in the real world.
