### PR TITLE
The ignore_bad_cookies argument of parse_request did not ignore InvalidC...

### DIFF
--- a/cookies.py
+++ b/cookies.py
@@ -1042,14 +1042,14 @@ class Cookies(dict):
                 cookie_dict = {'name': name, 'value': value}
                 try:
                     cookie = self.cookie_class.from_dict(cookie_dict)
-                except InvalidCookieError:
+                except CookieError:
                     if not ignore_bad_cookies:
                         raise
                 else:
                     cookie_objects.append(cookie)
         try:
             self.add(*cookie_objects)
-        except InvalidCookieError:
+        except CookieError:
             if not ignore_bad_cookies:
                 raise
             _report_invalid_cookie(header_data)


### PR DESCRIPTION
...ookieAttributeError which actually raised when parsing one cookie. Now the CookieError is catched there instead of InvalidCookieError

Here is the stack trace:

Error occured in Store.on_proxy: "", stack trace: Traceback (most recent call last):
  File "store.py", line 63, in on_proxy
    request_data = parse_request_data(request_data_unpacked)
  File "/var/spool/cocaine/store/omnibox/common.py", line 137, in parse_request_data
    all_cookies.from_request(headers['cookie'], True)
  File "/var/spool/cocaine/store/cookies.py", line 1107, in from_request
    header_data, ignore_bad_cookies=ignore_bad_cookies)
  File "/var/spool/cocaine/store/cookies.py", line 1044, in parse_request
    cookie = self.cookie_class.from_dict(cookie_dict)
  File "/var/spool/cocaine/store/cookies.py", line 740, in from_dict
    cookie = cls(name, value)
  File "/var/spool/cocaine/store/cookies.py", line 702, in **init**
    self.value = value or ''
  File "/var/spool/cocaine/store/cookies.py", line 814, in **setattr**
    repr(self.attribute_validators.get(name)))
InvalidCookieAttributeError: did not validate with <function valid_value at 0x21fcc80>: 'value' = u'197.1487.1.1.utmcsr=yadgo.ru|utmccn=(referral)|utmcmd=referral|utmcct=/r/http://ad....';
